### PR TITLE
Remove BOM character

### DIFF
--- a/SlidingMarker.js
+++ b/SlidingMarker.js
@@ -1,4 +1,4 @@
-﻿/* global define,module,require,google */
+/* global define,module,require,google */
 
 (function (root, factory) {
     'use strict';


### PR DESCRIPTION
BOM character throws JS errors.
In Jasmine:
<img width="1145" alt="Screen Shot 2021-05-23 at 12 22 16 PM" src="https://user-images.githubusercontent.com/20615/119273834-9a7e9000-bbc1-11eb-9464-ba306aaca07a.png">

In Chrome:
<img width="324" alt="Screen Shot 2021-05-23 at 12 22 28 PM" src="https://user-images.githubusercontent.com/20615/119273837-9c485380-bbc1-11eb-8aa5-03daaf46cb12.png">

